### PR TITLE
:bug: Fix number parsing on non-english locales

### DIFF
--- a/src/CodeMade.ScriptedGraphics.Tests/ColorTests.cs
+++ b/src/CodeMade.ScriptedGraphics.Tests/ColorTests.cs
@@ -2,6 +2,8 @@
 using NUnit.Framework;
 using System;
 using System.Drawing;
+using System.Globalization;
+using System.Threading;
 
 namespace CodeMade.ScriptedGraphics.Tests
 {
@@ -38,6 +40,18 @@ namespace CodeMade.ScriptedGraphics.Tests
 
             Assert.AreEqual(Color.Blue.ToArgb(), "#0000ffff".ToColor().ToArgb());
             Assert.AreEqual(Color.Green.ToArgb(), "#008000ff".ToColor().ToArgb());
+        }
+
+        [TestCase("en-US")]
+        [TestCase("it-IT")]
+        [TestCase("fr-FR")]
+        public void Parse_Gradients(string threadCulture)
+        {
+            var culture = new CultureInfo(threadCulture);
+            Thread.CurrentThread.CurrentCulture = culture;
+            Thread.CurrentThread.CurrentUICulture = culture;
+
+            var  color = Colors.Colors.ParseBrush("(0.5,0.5)-red-green-blue", new RectangleF(0, 0, 100, 100));
         }
     }
 }

--- a/src/CodeMade.ScriptedGraphics/Colors/Color.cs
+++ b/src/CodeMade.ScriptedGraphics/Colors/Color.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -54,6 +55,8 @@ namespace CodeMade.ScriptedGraphics.Colors
     /// </summary>
     public static class Colors
     {
+        private static CultureInfo _cultureInfo = new CultureInfo("en-US");
+
         public static IEnumerable<BrushOrColoredRegion> ParseBrush(this string s, RectangleF rect)
         {
             if (string.IsNullOrEmpty(s))
@@ -89,12 +92,12 @@ namespace CodeMade.ScriptedGraphics.Colors
                 throw new FormatException($"Invalid radial gradient format: `{s}`");
             }
             var coords = matches.Groups[1].Value.Split(", ".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
-            var x = float.Parse(coords[0]);
-            var y = float.Parse(coords[1]);
+            var x = float.Parse(coords[0], _cultureInfo);
+            var y = float.Parse(coords[1], _cultureInfo);
             var sz = 1.0f;
             if(coords.Length == 3)
             {
-                sz = float.Parse(coords[2]);
+                sz = float.Parse(coords[2], _cultureInfo);
             }
             var colors = matches.Groups[2].Value.Split("-".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
 
@@ -115,13 +118,13 @@ namespace CodeMade.ScriptedGraphics.Colors
             }
             else if (parts.Length == 3)
             {
-                angle = float.Parse(parts[0]);
+                angle = float.Parse(parts[0], _cultureInfo);
                 color1 = parts[1].ToColor();
                 color2 = parts[2].ToColor();
             }
             else
             {
-                angle = float.Parse(parts[0]);
+                angle = float.Parse(parts[0], _cultureInfo);
                 var colors = parts.Skip(1).Select(x => x.ToColor()).ToArray();
                 var multiColorBrush = new LinearGradientBrush(rect, Color.DeepPink, Color.DeepPink, angle)
                 {
@@ -153,8 +156,8 @@ namespace CodeMade.ScriptedGraphics.Colors
                     var parts = split.Split(", ()".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
                     if (parts.Length == 2)
                     {
-                        cx = float.Parse(parts[0]);
-                        cy = float.Parse(parts[1]);
+                        cx = float.Parse(parts[0], _cultureInfo);
+                        cy = float.Parse(parts[1], _cultureInfo);
                     }
                     continue;
                 }

--- a/src/CodeMade.ScriptedGraphics/Shape.cs
+++ b/src/CodeMade.ScriptedGraphics/Shape.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
+using System.Globalization;
 using System.Linq;
 using System.Xml.Serialization;
 
@@ -45,6 +46,7 @@ namespace CodeMade.ScriptedGraphics
             }
         }
 
+        private static CultureInfo _cultureInfo = new CultureInfo("en-US");
 
         public static IEnumerable<Vertex> VertexArrayFromString(string path)
         {
@@ -56,11 +58,11 @@ namespace CodeMade.ScriptedGraphics
             {
                 if (i % 2 == 0)
                 {
-                    v = new Vertex() { X = float.Parse(numbers[i]) };
+                    v = new Vertex() { X = float.Parse(numbers[i], _cultureInfo) };
                 }
                 else
                 {
-                    v.Y = float.Parse(numbers[i]);
+                    v.Y = float.Parse(numbers[i], _cultureInfo);
                     yield return v;
                 }
             }


### PR DESCRIPTION
The numbers in the skin json file are always stored in the en-us locale (ie, using . as the decimal separator)